### PR TITLE
Handle NaNs in revenue calculation for MPC metrics

### DIFF
--- a/OPEN_EV_case_study.py
+++ b/OPEN_EV_case_study.py
@@ -44,7 +44,7 @@ run_opt = 1
 # Added heuristic strategies 'tou' (time-of-use rule) and 'valley'
 # (valley-filling greedy)
 # opt_type = ['open_loop', 'mpc', 'uncontrolled', 'edf', 'tou', 'valley', 'lp']
-opt_type = ['open_loop', 'uncontrolled', 'edf', 'tou', 'valley', 'lp']
+opt_type = ['open_loop', 'mpc', 'uncontrolled', 'edf', 'tou', 'valley', 'lp']
 
 
 path_string = normpath('Results/EV_Case_Study/')

--- a/System/Markets.py
+++ b/System/Markets.py
@@ -131,14 +131,19 @@ class Market:
             Total revenue generated during simulation
 
         """
-        #convert import power to the market time-series
+        # Remove any NaN values before aggregation
+        P_import_tot = np.nan_to_num(P_import_tot)
+
+        # Convert import power to the market time-series
         P_import_market = np.zeros(self.T_market)
         for t_market in range(self.T_market):
             t_indexes = (t_market*self.dt_market/dt \
-                         + np.arange(0,self.dt_market/dt)).astype(int)
-            P_import_market[t_market] = np.mean(P_import_tot[t_indexes])
-        #calcuate the revenue
-        P_max_demand = np.max(P_import_market)
+                         + np.arange(0, self.dt_market/dt)).astype(int)
+            P_import_market[t_market] = np.nanmean(P_import_tot[t_indexes])
+        P_import_market = np.nan_to_num(P_import_market)
+
+        # Calculate the revenue using NaN-safe operations
+        P_max_demand = np.nanmax(P_import_market)
         P_import = np.maximum(P_import_market,0)
         P_export = np.maximum(-P_import_market,0)
         revenue = -self.demand_charge*P_max_demand+\


### PR DESCRIPTION
## Summary
- sanitize network import profiles in `Market.calculate_revenue` using `nan_to_num`, `nanmean`, and `nanmax`
- include `mpc` in the `opt_type` list so MPC results are recorded

## Testing
- `python OPEN_EV_case_study.py` *(fails: AttributeError: 'DataFrame' object has no attribute 'append')*

------
https://chatgpt.com/codex/tasks/task_e_68ae66741a38832c982cc4fe33494f94