### PR TITLE
Add composite and Pareto EV charging strategies

### DIFF
--- a/OPEN_EV_case_study.py
+++ b/OPEN_EV_case_study.py
@@ -42,9 +42,11 @@ __version__ = "1.0.0"
 run_opt = 1
 # list of strategies to evaluate
 # Added heuristic strategies 'tou' (time-of-use rule) and 'valley'
-# (valley-filling greedy)
-# opt_type = ['open_loop', 'mpc', 'uncontrolled', 'edf', 'tou', 'valley', 'lp']
-opt_type = ['open_loop', 'mpc', 'uncontrolled', 'edf', 'tou', 'valley', 'lp']
+# (valley-filling greedy) and new composite and Pareto-based strategies
+# opt_type = ['open_loop', 'mpc', 'uncontrolled', 'edf', 'tou', 'valley', 'lp',
+#             'composite', 'pareto']
+opt_type = ['open_loop', 'mpc', 'uncontrolled', 'edf', 'tou', 'valley', 'lp',
+            'composite', 'pareto']
 
 
 path_string = normpath('Results/EV_Case_Study/')
@@ -803,6 +805,110 @@ if run_opt ==1:
                     energy_needed -= P_ch * dt
             output = energy_system.simulate_network_manual_dispatch(P_ESs)
 
+        if x == "composite":
+            # Composite score strategy with network constraints
+            P_ESs = np.zeros((T, N_ESs))
+            E_state = E0_EVs.copy()
+            t_a_dt = (ta_EVs * dt_ems / dt).astype(int)
+            t_d_dt = (td_EVs * dt_ems / dt).astype(int)
+            price_max = np.max(market.prices_import)
+            wait_max = 24  # hours
+            w_wait = 1 / 3
+            w_req = 1 / 3
+            w_price = 1 / 3
+            for t in range(T):
+                t_ems = int(t / (dt_ems / dt))
+                P_avail = max(market.Pmax[t_ems] - P_demand_base[t], 0)
+                connected = [i for i in range(N_EVs)
+                             if t_a_dt[i] <= t < t_d_dt[i] and E_state[i] < Emax_EV]
+                if not connected or P_avail <= 0:
+                    continue
+                scores = []
+                for i in connected:
+                    wait = (t - t_a_dt[i]) * dt
+                    wait_norm = wait / wait_max if wait_max > 0 else 0
+                    deficit = Emax_EV - E_state[i]
+                    remaining_time = max((t_d_dt[i] - t) * dt, dt)
+                    required_power = min(deficit / remaining_time, P_max_EV)
+                    req_norm = (required_power / market.Pmax[t_ems]
+                                if market.Pmax[t_ems] > 0 else 0)
+                    price_norm = (1 - market.prices_import[t_ems] / price_max
+                                  if price_max > 0 else 0)
+                    score = w_wait * wait_norm + w_req * req_norm + w_price * price_norm
+                    scores.append((score, required_power, i))
+                scores.sort(reverse=True)
+                for score, required_power, i in scores:
+                    P_ch = min(required_power, P_avail, P_max_EV)
+                    if P_ch <= 0:
+                        continue
+                    P_ESs[t, i] = P_ch
+                    E_state[i] += P_ch * dt
+                    P_avail -= P_ch
+                    if P_avail <= 0:
+                        break
+            output = energy_system.simulate_network_manual_dispatch(P_ESs)
+
+        if x == "pareto":
+            # Pareto-based ranking strategy
+            P_ESs = np.zeros((T, N_ESs))
+            E_state = E0_EVs.copy()
+            t_a_dt = (ta_EVs * dt_ems / dt).astype(int)
+            t_d_dt = (td_EVs * dt_ems / dt).astype(int)
+            price_max = np.max(market.prices_import)
+            wait_max = 24  # hours
+            for t in range(T):
+                t_ems = int(t / (dt_ems / dt))
+                P_avail = max(market.Pmax[t_ems] - P_demand_base[t], 0)
+                connected = [i for i in range(N_EVs)
+                             if t_a_dt[i] <= t < t_d_dt[i] and E_state[i] < Emax_EV]
+                if not connected or P_avail <= 0:
+                    continue
+                objs = {}
+                for i in connected:
+                    wait_norm = ((t - t_a_dt[i]) * dt) / wait_max if wait_max > 0 else 0
+                    deficit = Emax_EV - E_state[i]
+                    remaining_time = max((t_d_dt[i] - t) * dt, dt)
+                    required_power = min(deficit / remaining_time, P_max_EV)
+                    req_norm = (required_power / market.Pmax[t_ems]
+                                if market.Pmax[t_ems] > 0 else 0)
+                    cost_norm = (market.prices_import[t_ems] / price_max
+                                 if price_max > 0 else 0)
+                    objs[i] = (wait_norm, req_norm, cost_norm, required_power)
+                remaining = set(connected)
+                fronts = []
+                while remaining:
+                    front = []
+                    for i in list(remaining):
+                        dominated = False
+                        for j in remaining:
+                            if i == j:
+                                continue
+                            oi = objs[i]
+                            oj = objs[j]
+                            if (oj[0] <= oi[0] and oj[1] <= oi[1] and oj[2] <= oi[2]
+                                    and (oj[0] < oi[0] or oj[1] < oi[1] or oj[2] < oi[2])):
+                                dominated = True
+                                break
+                        if not dominated:
+                            front.append(i)
+                    fronts.append(front)
+                    remaining -= set(front)
+                for front in fronts:
+                    front.sort(key=lambda i: objs[i][1], reverse=True)
+                    for i in front:
+                        required_power = objs[i][3]
+                        P_ch = min(required_power, P_avail, P_max_EV)
+                        if P_ch <= 0:
+                            continue
+                        P_ESs[t, i] = P_ch
+                        E_state[i] += P_ch * dt
+                        P_avail -= P_ch
+                        if P_avail <= 0:
+                            break
+                    if P_avail <= 0:
+                        break
+            output = energy_system.simulate_network_manual_dispatch(P_ESs)
+
         if x == "lp":
             for nd in nondispatch_assets: # for every non-dispatachable asset in the network, set predicited power to actual power for whole day
                 nd.Pnet_pred = nd.Pnet.copy()
@@ -905,6 +1011,18 @@ if run_opt ==1:
                             Pnet_market, storage_assets, N_ESs, nondispatch_assets,\
                             time_ems, time, timeE, buses_Vpu)
             pickle.dump(pickled_data_LP, open(join(path_string, normpath("EV_case_data_lp.p")), "wb"))
+
+        if x == "composite":
+            pickled_data_COMP = (N_EVs, P_demand_base_pred_ems, P_compare, P_demand_base,\
+                            Pnet_market, storage_assets, N_ESs, nondispatch_assets,\
+                            time_ems, time, timeE, buses_Vpu)
+            pickle.dump(pickled_data_COMP, open(join(path_string, normpath("EV_case_data_composite.p")), "wb"))
+
+        if x == "pareto":
+            pickled_data_PAR = (N_EVs, P_demand_base_pred_ems, P_compare, P_demand_base,\
+                            Pnet_market, storage_assets, N_ESs, nondispatch_assets,\
+                            time_ems, time, timeE, buses_Vpu)
+            pickle.dump(pickled_data_PAR, open(join(path_string, normpath("EV_case_data_pareto.p")), "wb"))
         
         
         figure_plot(x, N_EVs, P_demand_base_pred_ems, P_compare, P_demand_base,\
@@ -935,6 +1053,12 @@ else:
 
         if x == "lp":
             import_data = pickle.load(open(join(path_string, normpath("EV_case_data_lp.p")), "rb"))
+
+        if x == "composite":
+            import_data = pickle.load(open(join(path_string, normpath("EV_case_data_composite.p")), "rb"))
+
+        if x == "pareto":
+            import_data = pickle.load(open(join(path_string, normpath("EV_case_data_pareto.p")), "rb"))
 
         N_EVs = import_data[0]
         P_demand_base_pred_ems = import_data[1]


### PR DESCRIPTION
## Summary
- Extend strategy list to include new composite-score and Pareto-based EV charging controllers
- Implement composite-score priority allocation with network power limits
- Implement Pareto-front ranking allocation and persistence for result logging

## Testing
- `python -m py_compile OPEN_EV_case_study.py`
- `python OPEN_EV_case_study.py` *(fails: AttributeError: 'DataFrame' object has no attribute 'append')*


------
https://chatgpt.com/codex/tasks/task_e_68ae8f913e30832ca7550c5af3904a7e