### PR TITLE
Fix EV allocation loop control

### DIFF
--- a/OPEN_EV_case_study.py
+++ b/OPEN_EV_case_study.py
@@ -846,7 +846,7 @@ if run_opt ==1:
                         break
                     P_ch = min(required_power, P_avail)
                     if P_ch < min_chunk:
-                        break
+                        continue
                     P_ESs[t, i] = P_ch
                     E_state[i] += P_ch * dt
                     P_avail -= P_ch
@@ -909,7 +909,7 @@ if run_opt ==1:
                         required_power = objs[i][3]
                         P_ch = min(required_power, P_avail)
                         if P_ch < min_chunk:
-                            break
+                            continue
                         P_ESs[t, i] = P_ch
                         E_state[i] += P_ch * dt
                         P_avail -= P_ch


### PR DESCRIPTION
## Summary
- Allow composite strategy to skip undersized EV allocations without aborting further EVs
- Ensure Pareto strategy similarly continues when an EV's charge is below the minimum chunk

## Testing
- `pytest` *(fails: name 'pic' is not defined, ModuleNotFoundError: No module named 'System')*
- `python -m py_compile OPEN_EV_case_study.py`


------
https://chatgpt.com/codex/tasks/task_e_68b12a771a44832cad06d83c20b53289