### PR TITLE
Fix urgency direction for Pareto strategies

### DIFF
--- a/OPEN_EV_case_study.py
+++ b/OPEN_EV_case_study.py
@@ -923,8 +923,16 @@ if run_opt ==1:
                                 continue
                             oi = objs[i]
                             oj = objs[j]
-                            if (oj[0] <= oi[0] and oj[1] <= oi[1] and oj[2] <= oi[2]
-                                    and (oj[0] < oi[0] or oj[1] < oi[1] or oj[2] < oi[2])):
+                            if (
+                                oj[0] >= oi[0]
+                                and oj[1] >= oi[1]
+                                and oj[2] <= oi[2]
+                                and (
+                                    oj[0] > oi[0]
+                                    or oj[1] > oi[1]
+                                    or oj[2] < oi[2]
+                                )
+                            ):
                                 dominated = True
                                 break
                         if not dominated:
@@ -1097,8 +1105,16 @@ if run_opt ==1:
                                 continue
                             oi = objs[i]
                             oj = objs[j]
-                            if (oj[0] <= oi[0] and oj[1] <= oi[1] and oj[2] <= oi[2]
-                                    and (oj[0] < oi[0] or oj[1] < oi[1] or oj[2] < oi[2])):
+                            if (
+                                oj[0] >= oi[0]
+                                and oj[1] >= oi[1]
+                                and oj[2] <= oi[2]
+                                and (
+                                    oj[0] > oi[0]
+                                    or oj[1] > oi[1]
+                                    or oj[2] < oi[2]
+                                )
+                            ):
                                 dominated = True
                                 break
                         if not dominated:


### PR DESCRIPTION
## Summary
- Correct Pareto dominance test to treat longer waits and higher required power as higher urgency
- Apply the same dominance fix to Pareto MPC strategy

## Testing
- `python -m pytest -q` *(fails: NameError: name 'pic' is not defined; AttributeError: 'DataFrame' object has no attribute 'append')*

------
https://chatgpt.com/codex/tasks/task_e_68b907eea0f0832c8758207d828a9441