### PR TITLE
Add soft valley strategies for composite and pareto heuristics

### DIFF
--- a/OPEN_EV_case_study.py
+++ b/OPEN_EV_case_study.py
@@ -43,7 +43,8 @@ run_opt = 1
 # list of strats to evaluate
 # opt_type = ['open_loop', 'mpc', 'uncontrolled', 'edf', 'tou', 'valley', 'lp',
 #             'composite', 'pareto']
-opt_type = ['composite', 'pareto']
+# include soft variants with flexible valley filling
+opt_type = ['composite', 'pareto', 'composite_soft', 'pareto_soft']
 
 # valley softness determines how soft the valley-filling objective is. 1 is max
 valley_softness = 0.75
@@ -861,6 +862,148 @@ if run_opt ==1:
                                 if market.Pmax[t_ems] > 0 else 0)
                     cost_norm = (market.prices_import[t_ems] / price_max
                                  if price_max > 0 else 0)
+                    objs[i] = (wait_norm, req_norm, cost_norm, required_power)
+                remaining = set(connected)
+                fronts = []
+                while remaining:
+                    front = []
+                    for i in list(remaining):
+                        dominated = False
+                        for j in remaining:
+                            if i == j:
+                                continue
+                            oi = objs[i]
+                            oj = objs[j]
+                            if (
+                                oj[0] >= oi[0]
+                                and oj[1] >= oi[1]
+                                and oj[2] <= oi[2]
+                                and (
+                                    oj[0] > oi[0]
+                                    or oj[1] > oi[1]
+                                    or oj[2] < oi[2]
+                                )
+                            ):
+                                dominated = True
+                                break
+                        if not dominated:
+                            front.append(i)
+                    fronts.append(front)
+                    remaining -= set(front)
+                for front in fronts:
+                    front.sort(key=lambda i: objs[i][1], reverse=True)
+                    for i in front:
+                        if P_avail < min_chunk:
+                            break
+                        required_power = objs[i][3]
+                        P_charge = min(required_power, P_avail)
+                        if P_charge < min_chunk:
+                            continue
+                        P_ESs[t, i] = P_charge
+                        E_state[i] += P_charge * dt
+                        P_avail -= P_charge
+                    if P_avail < min_chunk:
+                        break
+            output = energy_system.simulate_network_manual_dispatch(P_ESs)
+
+        if x == "composite_soft":
+            # Composite strategy with soft valley weighting
+            P_ESs = np.zeros((T, N_ESs))
+            E_state = E0_EVs.copy()
+            t_arriv_dt = (tarriv_EVs * dt_ems / dt).astype(int)
+            t_depart_dt = (tdepart_EVs * dt_ems / dt).astype(int)
+            price_max = np.max(market.prices_import)
+            wait_max = 24  # hours
+            w_wait = 1 / 3
+            w_req = 1 / 3
+            w_price = 1 / 3
+            base_mean = np.mean(P_demand_base)
+            min_chunk = 0.1 * P_max_EV
+            for t in range(T):
+                t_ems = int(t / (dt_ems / dt))
+                P_network_cap = max(market.Pmax[t_ems] - P_demand_base[t], 0)
+                valley_weight = (
+                    min(base_mean / P_demand_base[t], 1)
+                    if P_demand_base[t] > 0
+                    else 1
+                )
+                P_avail = P_network_cap * valley_weight
+                connected = [
+                    i for i in range(N_EVs)
+                    if t_arriv_dt[i] <= t < t_depart_dt[i] and E_state[i] < Emax_EV
+                ]
+                if not connected or P_avail < min_chunk:
+                    continue
+                scores = []
+                for i in connected:
+                    wait = (t - t_arriv_dt[i]) * dt
+                    wait_norm = wait / wait_max if wait_max > 0 else 0
+                    deficit = Emax_EV - E_state[i]
+                    required_power = min(deficit / dt, P_max_EV)
+                    req_norm = (
+                        required_power / market.Pmax[t_ems]
+                        if market.Pmax[t_ems] > 0
+                        else 0
+                    )
+                    price_norm = (
+                        1 - market.prices_import[t_ems] / price_max
+                        if price_max > 0
+                        else 0
+                    )
+                    score = w_wait * wait_norm + w_req * req_norm + w_price * price_norm
+                    scores.append((score, required_power, i))
+                scores.sort(reverse=True)
+                for score, required_power, i in scores:
+                    if P_avail < min_chunk:
+                        break
+                    P_charge = min(required_power, P_avail)
+                    if P_charge < min_chunk:
+                        continue
+                    P_ESs[t, i] = P_charge
+                    E_state[i] += P_charge * dt
+                    P_avail -= P_charge
+            output = energy_system.simulate_network_manual_dispatch(P_ESs)
+
+        if x == "pareto_soft":
+            # Pareto strategy with soft valley weighting
+            P_ESs = np.zeros((T, N_ESs))
+            E_state = E0_EVs.copy()
+            t_arriv_dt = (tarriv_EVs * dt_ems / dt).astype(int)
+            t_depart_dt = (tdepart_EVs * dt_ems / dt).astype(int)
+            price_max = np.max(market.prices_import)
+            wait_max = 24  # hours
+            base_mean = np.mean(P_demand_base)
+            min_chunk = 0.1 * P_max_EV
+            for t in range(T):
+                t_ems = int(t / (dt_ems / dt))
+                P_network_cap = max(market.Pmax[t_ems] - P_demand_base[t], 0)
+                valley_weight = (
+                    min(base_mean / P_demand_base[t], 1)
+                    if P_demand_base[t] > 0
+                    else 1
+                )
+                P_avail = P_network_cap * valley_weight
+                connected = [
+                    i for i in range(N_EVs)
+                    if t_arriv_dt[i] <= t < t_depart_dt[i] and E_state[i] < Emax_EV
+                ]
+                if not connected or P_avail < min_chunk:
+                    continue
+                objs = {}
+                for i in connected:
+                    wait_norm = ((t - t_arriv_dt[i]) * dt) / wait_max if wait_max > 0 else 0
+                    deficit = Emax_EV - E_state[i]
+                    required_power = min(deficit / dt, P_max_EV)
+                    req_norm = (
+                        required_power / market.Pmax[t_ems]
+                        if market.Pmax[t_ems] > 0
+                        else 0
+                    )
+                    cost_norm = (
+                        market.prices_import[t_ems] / price_max
+                        if price_max > 0
+                        else 0
+                    )
                     objs[i] = (wait_norm, req_norm, cost_norm, required_power)
                 remaining = set(connected)
                 fronts = []


### PR DESCRIPTION
## Summary
- Introduce `composite_soft` and `pareto_soft` strategies that scale charging using a valley weight instead of a hard cap.
- Allow strategy selection to include soft variants by default.

## Testing
- `pytest` *(fails: NameError: name 'pic' is not defined; ModuleNotFoundError: No module named 'System')*

------
https://chatgpt.com/codex/tasks/task_e_68b915dd1894832cbfd47236567949f3