### PR TITLE
Slant strategy labels in performance metrics plots

### DIFF
--- a/OPEN_EV_case_study.py
+++ b/OPEN_EV_case_study.py
@@ -274,6 +274,7 @@ def plot_performance_metrics(metrics, path): #print performance metrics for all 
         plt.bar(strats, vals)
         plt.ylabel(ylabel)
         plt.xlabel('Strategy')
+        plt.xticks(rotation=45, ha='right')
         plt.tight_layout()
         plt.savefig(join(path, normpath(filename + save_suffix)), bbox_inches='tight')
         plt.close()
@@ -293,6 +294,7 @@ def plot_performance_metrics(metrics, path): #print performance metrics for all 
             label='Additional Imported Power', color='orange')
     plt.ylabel('Power (kW)')
     plt.xlabel('Strategy')
+    plt.xticks(rotation=45, ha='right')
     plt.legend()
     plt.tight_layout()
     plt.savefig(join(path, normpath('import_power_combined' + save_suffix)),
@@ -327,6 +329,7 @@ def plot_performance_metrics(metrics, path): #print performance metrics for all 
         plt.figure(num=None, figsize=(6, 2.5), dpi=80, facecolor='w', edgecolor='k')
         plt.boxplot([metrics['waiting_times'][s] for s in strats], labels=strats)
         plt.ylabel('Waiting Time per EV (h)')
+        plt.xticks(rotation=45, ha='right')
         plt.tight_layout()
         plt.savefig(join(path, normpath('waiting_time_per_ev' + save_suffix)),
                     bbox_inches='tight')
@@ -356,6 +359,7 @@ def plot_performance_metrics(metrics, path): #print performance metrics for all 
                        edgecolor='k')
             plt.boxplot(data, labels=labels)
             plt.ylabel('Energy Deficit at Departure (kWh)')
+            plt.xticks(rotation=45, ha='right')
             plt.tight_layout()
             plt.savefig(join(path, normpath('energy_deficit_per_ev' + save_suffix)),
                         bbox_inches='tight')


### PR DESCRIPTION
## Summary
- Rotate strategy labels in performance metric bar plots
- Apply rotated tick labels to combined import-power chart
- Slant strategy labels in waiting-time and energy-deficit boxplots

## Testing
- `pytest` *(fails: NameError: name 'pic' is not defined; ModuleNotFoundError: No module named 'System')*

------
https://chatgpt.com/codex/tasks/task_e_68bec44853c4832cbd008fb512b0ce1d